### PR TITLE
feat: add export for proposals / multisig

### DIFF
--- a/api/src/routes/proposals.ts
+++ b/api/src/routes/proposals.ts
@@ -383,6 +383,7 @@ proposalsRouter.get('/digest/:digest', async (c) => {
 		totalWeight: multisig.threshold,
 		multisig: {
 			address: multisig.address,
+			name: multisig.name,
 			threshold: multisig.threshold,
 			members: multisig.members.map((member) => ({
 				publicKey: member.publicKey,

--- a/app/src/components/proposals/ProposalCard.tsx
+++ b/app/src/components/proposals/ProposalCard.tsx
@@ -14,6 +14,7 @@ import {
 	Check,
 	ChevronDown,
 	ChevronRight,
+	Download,
 	ExternalLink,
 	Eye,
 	Rocket,
@@ -29,11 +30,22 @@ import { useCancelProposal } from '../../hooks/useCancelProposal';
 import { useExecuteProposal } from '../../hooks/useExecuteProposal';
 import { useSignProposal } from '../../hooks/useSignProposal';
 import { useVerifyProposal } from '../../hooks/useVerifyProposal';
+import {
+	buildProposalExport,
+	downloadJson,
+	getProposalExportFilename,
+} from '../../lib/exportUtils';
 import { validatePublicKey } from '../../lib/sui-utils';
 import { CancelProposalModal } from '../modals/CancelProposalModal';
 import { Button } from '../ui/button';
 import { CopyButton } from '../ui/copy-button';
 import { Label } from '../ui/label';
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from '../ui/tooltip';
 import { ProposalPreview } from './ProposalPreview';
 
 interface ProposalCardProps {
@@ -85,6 +97,13 @@ export function ProposalCard({
 				setShowCancelModal(false);
 			},
 		});
+	};
+
+	const handleExportProposal = () => {
+		downloadJson(
+			getProposalExportFilename(proposal.digest),
+			buildProposalExport(proposal),
+		);
 	};
 
 	const currentWallet = useCurrentAccount();
@@ -217,6 +236,25 @@ export function ProposalCard({
 								size="sm"
 								successMessage="Copied digest to clipboard"
 							/>
+							{!proposal.isPublic && (
+								<TooltipProvider delayDuration={150}>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={handleExportProposal}
+												className="inline-flex items-center justify-center rounded p-0.5 transition-colors hover:bg-accent cursor-pointer"
+												aria-label="Export proposal with signatures"
+											>
+												<Download className="w-3 h-3 text-muted-foreground hover:text-foreground" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent>
+											Export proposal with signatures
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							)}
 						</div>
 					</div>
 				</div>

--- a/app/src/components/tabs/OverviewTab.tsx
+++ b/app/src/components/tabs/OverviewTab.tsx
@@ -4,6 +4,7 @@
 import {
 	Check,
 	Copy,
+	Download,
 	ExternalLink,
 	Users,
 } from 'lucide-react';
@@ -15,6 +16,11 @@ import { type MultisigWithMembersForPublicKey } from '@/lib/types';
 import { useNetwork } from '../../contexts/NetworkContext';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { CONFIG } from '../../lib/constants';
+import {
+	buildMultisigCompositionExport,
+	downloadJson,
+	getMultisigExportFilename,
+} from '../../lib/exportUtils';
 import { MembersList } from '../invitations/MembersList';
 import { ProposersSection } from '../proposers/ProposersSection';
 import { Button } from '../ui/button';
@@ -41,6 +47,15 @@ export function OverviewTab() {
 		error,
 		refetch,
 	} = useGetMultisig(multisig.address);
+
+	const handleExportComposition = () => {
+		downloadJson(
+			getMultisigExportFilename(multisig.address),
+			buildMultisigCompositionExport(
+				multisigDetails ?? multisig,
+			),
+		);
+	};
 
 	return (
 		<div className="space-y-6">
@@ -90,8 +105,7 @@ export function OverviewTab() {
 					</div>
 				</div>
 
-				{/* Explorer Link */}
-				<div className="mt-6 pt-6 border-t">
+				<div className="mt-6 pt-6 border-t flex flex-col sm:flex-row gap-2">
 					<Button
 						variant="outline"
 						onClick={() =>
@@ -104,6 +118,14 @@ export function OverviewTab() {
 					>
 						<ExternalLink className="w-4 h-4 mr-2" />
 						View on Sui Explorer
+					</Button>
+					<Button
+						variant="outline"
+						onClick={handleExportComposition}
+						className="w-full sm:w-auto"
+					>
+						<Download className="w-4 h-4 mr-2" />
+						Download
 					</Button>
 				</div>
 			</div>

--- a/app/src/components/tabs/ProposalsTab.tsx
+++ b/app/src/components/tabs/ProposalsTab.tsx
@@ -149,6 +149,7 @@ function ProposalsList({
 			),
 			multisig: {
 				address: multisig.address,
+				name: multisig.name,
 				threshold: multisig.threshold,
 				members: multisig.members.map((member) => ({
 					...member,

--- a/app/src/lib/exportUtils.ts
+++ b/app/src/lib/exportUtils.ts
@@ -1,0 +1,206 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ProposalStatus,
+	type MultisigWithMembers,
+	type PublicProposal,
+} from '@mysten/sagat';
+
+type ExportType =
+	| 'sagat.multisig-composition'
+	| 'sagat.proposal';
+
+interface ExportEnvelope {
+	type: ExportType;
+	version: 1;
+}
+
+interface ExportedMultisigMember {
+	publicKey: string;
+	weight: number;
+	order: number;
+}
+
+interface MultisigCompositionInput {
+	address: string;
+	name: string | null;
+	threshold: number;
+	members: ExportedMultisigMember[];
+}
+
+interface ExportedMultisigComposition extends ExportEnvelope {
+	type: 'sagat.multisig-composition';
+	multisig: {
+		address: string;
+		name: string | null;
+		threshold: number;
+		totalWeight: number;
+		totalMembers: number;
+		members: ExportedMultisigMember[];
+	};
+}
+
+interface ExportedProposalSignature {
+	proposalId: number;
+	publicKey: string;
+	signature: string;
+	weight: number | null;
+	order: number | null;
+}
+
+interface ExportedProposal extends ExportEnvelope {
+	type: 'sagat.proposal';
+	exportedAt: string;
+	proposal: {
+		id: number;
+		digest: string;
+		network: string;
+		multisigAddress: string;
+		status: ProposalStatus;
+		statusLabel: string;
+		transactionBytes: string;
+		proposerAddress: string;
+		description: string | null;
+		currentWeight: number;
+		threshold: number;
+		signatures: ExportedProposalSignature[];
+	};
+	multisig: ExportedMultisigComposition['multisig'];
+}
+
+export function buildMultisigCompositionExport(
+	multisig: MultisigWithMembers,
+): ExportedMultisigComposition {
+	return {
+		type: 'sagat.multisig-composition',
+		version: 1,
+		multisig: buildMultisigComposition(multisig),
+	};
+}
+
+export function buildProposalExport(
+	proposal: PublicProposal,
+	now = new Date(),
+): ExportedProposal {
+	const multisig = buildMultisigComposition({
+		...proposal.multisig,
+		name: proposal.multisig.name ?? null,
+	});
+	const memberByPublicKey = new Map(
+		multisig.members.map((member) => [
+			member.publicKey,
+			member,
+		]),
+	);
+
+	return {
+		type: 'sagat.proposal',
+		version: 1,
+		exportedAt: now.toISOString(),
+		proposal: {
+			id: proposal.id,
+			digest: proposal.digest,
+			network: proposal.network,
+			multisigAddress: proposal.multisigAddress,
+			status: proposal.status,
+			statusLabel: getProposalStatusLabel(proposal.status),
+			transactionBytes: proposal.transactionBytes,
+			proposerAddress: proposal.proposerAddress,
+			description: proposal.description,
+			currentWeight: proposal.currentWeight,
+			threshold: proposal.multisig.threshold,
+			signatures: proposal.signatures
+				.map((signature) => {
+					const member = memberByPublicKey.get(
+						signature.publicKey,
+					);
+					return {
+						proposalId: signature.proposalId,
+						publicKey: signature.publicKey,
+						signature: signature.signature,
+						weight: member?.weight ?? null,
+						order: member?.order ?? null,
+					};
+				})
+				.sort((a, b) => {
+					if (a.order === null && b.order === null) {
+						return a.publicKey.localeCompare(b.publicKey);
+					}
+					if (a.order === null) return 1;
+					if (b.order === null) return -1;
+					return a.order - b.order;
+				}),
+		},
+		multisig,
+	};
+}
+
+export function downloadJson(
+	filename: string,
+	data: unknown,
+) {
+	const blob = new Blob(
+		[`${JSON.stringify(data, null, 2)}\n`],
+		{
+			type: 'application/json;charset=utf-8',
+		},
+	);
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
+
+	link.href = url;
+	link.download = filename;
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+}
+
+export function getMultisigExportFilename(
+	multisigAddress: string,
+) {
+	return `sagat-multisig-${sanitizeFilenameSegment(multisigAddress)}.json`;
+}
+
+export function getProposalExportFilename(digest: string) {
+	return `sagat-proposal-${sanitizeFilenameSegment(digest)}.json`;
+}
+
+function getOrderedMembers(
+	members: ExportedMultisigMember[],
+): ExportedMultisigMember[] {
+	return members
+		.map((member) => ({
+			publicKey: member.publicKey,
+			weight: member.weight,
+			order: member.order,
+		}))
+		.sort((a, b) => a.order - b.order);
+}
+
+function buildMultisigComposition(
+	multisig: MultisigCompositionInput,
+): ExportedMultisigComposition['multisig'] {
+	const members = getOrderedMembers(multisig.members);
+
+	return {
+		address: multisig.address,
+		name: multisig.name,
+		threshold: multisig.threshold,
+		totalWeight: members.reduce(
+			(sum, member) => sum + member.weight,
+			0,
+		),
+		totalMembers: members.length,
+		members,
+	};
+}
+
+function getProposalStatusLabel(status: ProposalStatus) {
+	return ProposalStatus[status] ?? 'UNKNOWN';
+}
+
+function sanitizeFilenameSegment(value: string) {
+	return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}

--- a/app/test/export-utils.test.ts
+++ b/app/test/export-utils.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ProposalStatus,
+	type MultisigWithMembers,
+	type PublicProposal,
+} from '@mysten/sagat';
+import { describe, expect, test } from 'vitest';
+
+import {
+	buildMultisigCompositionExport,
+	buildProposalExport,
+	getMultisigExportFilename,
+	getProposalExportFilename,
+} from '../src/lib/exportUtils';
+
+const exportedAt = new Date('2026-04-28T06:30:00.000Z');
+
+const multisig: MultisigWithMembers = {
+	address: '0xmultisig',
+	isVerified: false,
+	threshold: 3,
+	name: 'Treasury',
+	totalMembers: 3,
+	totalWeight: 6,
+	proposers: [],
+	members: [
+		{
+			multisigAddress: '0xmultisig',
+			publicKey: 'member-c',
+			weight: 3,
+			isAccepted: false,
+			isRejected: false,
+			order: 2,
+		},
+		{
+			multisigAddress: '0xmultisig',
+			publicKey: 'member-a',
+			weight: 1,
+			isAccepted: true,
+			isRejected: false,
+			order: 0,
+		},
+		{
+			multisigAddress: '0xmultisig',
+			publicKey: 'member-b',
+			weight: 2,
+			isAccepted: true,
+			isRejected: false,
+			order: 1,
+		},
+	],
+};
+
+describe('export utils', () => {
+	test('builds a narrow multisig composition export', () => {
+		const result = buildMultisigCompositionExport(multisig);
+
+		expect(result).toEqual({
+			type: 'sagat.multisig-composition',
+			version: 1,
+			multisig: {
+				address: '0xmultisig',
+				name: 'Treasury',
+				threshold: 3,
+				totalWeight: 6,
+				totalMembers: 3,
+				members: [
+					{ publicKey: 'member-a', weight: 1, order: 0 },
+					{ publicKey: 'member-b', weight: 2, order: 1 },
+					{ publicKey: 'member-c', weight: 3, order: 2 },
+				],
+			},
+		});
+	});
+
+	test('associates proposal signatures with multisig member weights', () => {
+		const proposal: PublicProposal = {
+			id: 42,
+			digest: '0xdigest',
+			status: ProposalStatus.PENDING,
+			transactionBytes: 'transaction-bytes',
+			proposerAddress: '0xproposer',
+			description: 'Pay supplier',
+			totalWeight: 3,
+			currentWeight: 3,
+			network: 'testnet',
+			multisigAddress: '0xmultisig',
+			signatures: [
+				{
+					proposalId: 42,
+					publicKey: 'member-b',
+					signature: 'sig-b',
+				},
+				{
+					proposalId: 42,
+					publicKey: 'member-a',
+					signature: 'sig-a',
+				},
+			],
+			multisig: {
+				address: '0xmultisig',
+				name: 'Treasury',
+				threshold: 3,
+				members: [
+					{ publicKey: 'member-b', weight: 2, order: 1 },
+					{ publicKey: 'member-a', weight: 1, order: 0 },
+					{ publicKey: 'member-c', weight: 3, order: 2 },
+				],
+			},
+		};
+
+		const result = buildProposalExport(
+			proposal,
+			exportedAt,
+		);
+
+		expect(result).toMatchObject({
+			type: 'sagat.proposal',
+			version: 1,
+			exportedAt: exportedAt.toISOString(),
+			proposal: {
+				id: 42,
+				digest: '0xdigest',
+				network: 'testnet',
+				multisigAddress: '0xmultisig',
+				status: ProposalStatus.PENDING,
+				statusLabel: 'PENDING',
+				transactionBytes: 'transaction-bytes',
+				proposerAddress: '0xproposer',
+				description: 'Pay supplier',
+				currentWeight: 3,
+				threshold: 3,
+				signatures: [
+					{
+						proposalId: 42,
+						publicKey: 'member-a',
+						signature: 'sig-a',
+						weight: 1,
+						order: 0,
+					},
+					{
+						proposalId: 42,
+						publicKey: 'member-b',
+						signature: 'sig-b',
+						weight: 2,
+						order: 1,
+					},
+				],
+			},
+		});
+		expect(result.multisig.name).toBe('Treasury');
+		expect(result.multisig.members).toEqual([
+			{ publicKey: 'member-a', weight: 1, order: 0 },
+			{ publicKey: 'member-b', weight: 2, order: 1 },
+			{ publicKey: 'member-c', weight: 3, order: 2 },
+		]);
+	});
+
+	test('sanitizes export filenames', () => {
+		expect(getMultisigExportFilename('0xabc/def')).toBe(
+			'sagat-multisig-0xabc_def.json',
+		);
+		expect(getProposalExportFilename('abc:def')).toBe(
+			'sagat-proposal-abc_def.json',
+		);
+	});
+});

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -23,6 +23,7 @@
 		/* Paths */
 		"baseUrl": ".",
 		"paths": {
+			"@mysten/sagat": ["../sdk/src/index.ts"],
 			"@/*": ["./src/*"]
 		}
 	},

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -9,6 +9,10 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			'@': path.resolve(__dirname, './src'),
+			'@mysten/sagat': path.resolve(
+				__dirname,
+				'../sdk/src/index.ts',
+			),
 		},
 	},
 });

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -96,6 +96,7 @@ export interface PublicProposal extends Proposal {
 	signatures: ProposalSignature[];
 	multisig: {
 		address: string;
+		name?: string | null;
 		threshold: number;
 		members: {
 			publicKey: string;


### PR DESCRIPTION
Adds buttons to export proposals as well as download the multisig composition to JSON.

Can be convenient to port to another method of signing! 

Proposals:
<img width="321" height="123" alt="Screenshot 2026-04-28 at 9 45 33 AM" src="https://github.com/user-attachments/assets/40c33c79-fadd-4835-a850-0233bbe8641d" />

Overview:
<img width="739" height="258" alt="Screenshot 2026-04-28 at 9 45 46 AM" src="https://github.com/user-attachments/assets/c6d768a9-6571-40f8-b5da-c4ed2d99db04" />
